### PR TITLE
Fix typo

### DIFF
--- a/005-On-the-lack-of-integrated-tooling-OCaml.md
+++ b/005-On-the-lack-of-integrated-tooling-OCaml.md
@@ -22,7 +22,7 @@ There is a current trope that while OCaml the language is decent the tooling is 
 
 Such is the case with OCaml. In its long evolution from 1996, it has had many build systems and ancillary tools. The growth of tooling has been organic and not resulted in a monolithic, super consistent tool like `cargo`. Its unfortunate but this is a legacy issue. But in 2021 I will recommend:
 
-### The OCaml Tooling Cannon for 2021
+### The OCaml Tooling Canon for 2021
 - Dune as your build tool
 - Opam as your package manager
 - [`ocaml-lsp-server`](https://github.com/ocaml/ocaml-lsp) as your LSP server (this has an associated vscode plugin if you're into VSCode), You can just use the lsp server directly if you are using Neovim (after you make the appropriate configuration in `lsp-config`). If you use Kakoune, then install the `kak-lsp` plugin which allows you to use a variety of LSPs with Kakoune (including the `ocaml-lsp-server`). 


### PR DESCRIPTION
I'm assuming you mean "canon" as in "canonical", in which case the proper spelling is one 'n'.